### PR TITLE
Refactor code for migration from obsolete get methods

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -9,10 +9,6 @@ const showcase = require('./projects/Showcase/showcase.js')
 // console.log(ddd)
 
 describe('testing if methods inside the files are accessible from the outside', () => {
-  test('[ChickenKyiv] recipe file is set', () => {
-    var stream = chickenKyiv.getRecipe()
-    expect(stream).not.toBe('')
-  })
 
   test('[ChickenKyiv] get recipe by title file is set', () => {
     var stream = chickenKyiv.getRecipeByTitle('Lemonade')

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,6 +10,12 @@ const showcase = require('./projects/Showcase/showcase.js')
 
 describe('testing if methods inside the files are accessible from the outside', () => {
 
+  //Test not required as getRecepie() is obsolete
+    // test('[ChickenKyiv] recipe file is set', () => {
+    //   var stream = chickenKyiv.getRecipe()
+    //   expect(stream).not.toBe('')
+    // })
+
   test('[ChickenKyiv] get recipe by title file is set', () => {
     var stream = chickenKyiv.getRecipeByTitle('Lemonade')
     expect(stream).not.toBe('')

--- a/src/projects/ChickenKyiv/chickenKyiv.js
+++ b/src/projects/ChickenKyiv/chickenKyiv.js
@@ -14,38 +14,6 @@ const files = {
   users
 } = require('./files')
 
-// @TODO can we update our methods - but we'll need to go step by step,
-// because these methods used in our react projects.
-// so I propose do it very carefully
-const getIngredients3 = function () {
-  return __get(ingredients3)
-}
-
-const getMenu = function () {
-  return __get(menus)
-}
-
-const getRecipe = function () {
-  return __get(recipes)
-}
-
-const getNutritions1 = function () {
-  return __get(nutritions1)
-}
-
-const getNutritions2 = function () {
-  return __get(nutritions2)
-}
-
-// duplicates from GS
-const getDepartments = function () {
-  return __get(departments)
-}
-
-const getUsers = function () {
-  return __get(users)
-}
-
 // @TODO update this method
 const getFiveRandomId = function () {
   return [
@@ -58,7 +26,7 @@ const getFiveRandomId = function () {
 }
 
 const getRecipes = function () {
-  let recipes = getRecipe()
+  let recipes = __get(files.recipes)
   let randomFiveIds = getFiveRandomId()
 
   let result =
@@ -96,7 +64,6 @@ const getMenuGenerator = (number_of_weeks) => {
 
 // @TODO replace it later. may need it at helper.js
 const getNRecipes = (n) => {
-
   return _.slice(recipes, n)
 }
 
@@ -105,9 +72,9 @@ const getNRecipes = (n) => {
  * @param  {string} title title of the recipe
  * @return {object}       recipe object
  */
-const getRecipeByTitle = title => {
-  let recipe; let recipes = getRecipe()
-
+const getRecipeByTitle = (title) => {
+  let recipe; 
+  let recipes = __get(files.recipes)
   // @TODO yeah it works, but if we'll replace it with lodash it'll be better.
   recipe = recipes.filter(recipe => recipe.title === title)
   return recipe[0]
@@ -163,21 +130,12 @@ const getFiveRandomIngredients = () => {
 }
 
 module.exports = {
-  getIngredients3,
-  getMenu,
-  getRecipe,
   getNRecipes,
-
   getRecipeByTitle,
   getRandomRecipe,
   getFirstFiveRecipes,
   getFiveRandomIngredients,
-  getNutritions1,
-  getNutritions2,
   getMenuGenerator,
-
-  getDepartments,
-  getUsers,
   getRecipes,
 
   files,

--- a/src/projects/ChickenKyiv/test/chickenKyiv.test.js
+++ b/src/projects/ChickenKyiv/test/chickenKyiv.test.js
@@ -4,6 +4,11 @@ const chickenKyiv = require('../chickenKyiv.js')
 
 // @TODO OK, but i don't like when you put everything in long line inside of your ass @hirdbluebird. Looks not better.
 describe('testing static data files are set', () => {
+  test('getRecipes', ()=> {
+    expect(chickenKyiv.getRecipes()).not.toBe('')
+    // console.log(chickenKyiv.getRecipes())
+  })
+  
   test('generate basic Weekly Menu objects', () => {
     expect(chickenKyiv.getMenuGenerator(1)).not.toBe('')
   })

--- a/src/projects/ChickenKyiv/test/chickenKyiv.test.js
+++ b/src/projects/ChickenKyiv/test/chickenKyiv.test.js
@@ -4,9 +4,9 @@ const chickenKyiv = require('../chickenKyiv.js')
 
 // @TODO OK, but i don't like when you put everything in long line inside of your ass @hirdbluebird. Looks not better.
 describe('testing static data files are set', () => {
-  test('getRecipes', ()=> {
+
+  test('getRecipes() returns recepie objects', ()=> {
     expect(chickenKyiv.getRecipes()).not.toBe('')
-    // console.log(chickenKyiv.getRecipes())
   })
   
   test('generate basic Weekly Menu objects', () => {


### PR DESCRIPTION
Removed obsolete `get` methods `/projects/chickenkyiv/ChickenKyiv.js` file.
Updated test methods to reflect removal of `getRecipe()`